### PR TITLE
Run only Flask server and drop audio capture subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ echo "OPENAI_API_KEY=your-api-key-here" > .env
 ```
 
 ## Usage
-Start the application:
+Start the server:
 ```bash
 python run.py
 ```
@@ -58,20 +58,18 @@ Agent_Bob/
 │   └── transcripts/      # Text transcripts
 ├── src/                  # Source code
 │   ├── app.py            # Flask application
-│   ├── audio_capture.py  # Audio recorder
+│   ├── audio_capture.py  # Audio recorder (legacy)
 │   ├── llm.py            # Response generator
 │   └── transcribe.py     # Audio-to-text
 ├── templates/            # Web interface
 │   └── index.html
 ├── .env                  # API key configuration
 ├── requirements.txt      # Dependencies
-└── run.py                # Control script
+└── run.py                # Flask server launcher
 ```
 
 ## Configuration
 - Set `OPENAI_API_KEY` in `.env`
-- Modify `audio_capture.py` for audio device settings
-- Adjust VAD sensitivity in `audio_capture.py` (VAD_AGGRESSIVENESS)
 
 ## Notes
 - Requires "Stereo Mix" enabled in Windows sound settings

--- a/run.py
+++ b/run.py
@@ -1,35 +1,15 @@
 import subprocess
 import sys
-import os
-import signal
-import time
-
-def run_flask():
-    """Start the Flask server"""
-    subprocess.run([sys.executable, "app.py"])
-
-def run_audio_capture():
-    """Start the audio capture"""
-    subprocess.run([sys.executable, "audio_capture.py"])
 
 if __name__ == "__main__":
     # Start Flask in a subprocess
     flask_process = subprocess.Popen([sys.executable, "src/app.py"])
-    
-    # Start audio capture in a subprocess
-    audio_process = subprocess.Popen([sys.executable, "src/audio_capture.py"])
-    
+
     try:
-        print("Both processes started. Press Ctrl+C to stop.")
-        # Wait indefinitely until interrupted
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        print("\nStopping processes...")
-        # Terminate both processes
-        flask_process.terminate()
-        audio_process.terminate()
-        # Wait for them to finish
+        print("Flask server started. Press Ctrl+C to stop.")
         flask_process.wait()
-        audio_process.wait()
-        print("Processes stopped.")
+    except KeyboardInterrupt:
+        print("\nStopping Flask server...")
+        flask_process.terminate()
+        flask_process.wait()
+        print("Flask server stopped.")

--- a/src/app.py
+++ b/src/app.py
@@ -333,7 +333,7 @@ def start_session():
 @app.route('/active-session', methods=['GET'])
 def active_session():
     """
-    Return the latest known session_id for non-cookie clients (like audio_capture.py).
+    Return the latest known session_id for non-cookie clients.
     Prefers the cookie session if available, else falls back to data/last_session_id.txt.
     """
     # 1) try cookie-backed Flask session


### PR DESCRIPTION
## Summary
- Simplify `run.py` to launch only the Flask server and remove the Python audio capture subprocess.
- Mark `audio_capture.py` as legacy and clean up documentation to remove references to running the audio capture script.
- Clarify session endpoint comment to reference generic non-cookie clients.

## Testing
- `python -m py_compile run.py src/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a48ecbd5588330afc9f5ca0263b6d0