### PR TITLE
Add PCM collector worklet and configure static serving

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ import json
 
 load_dotenv()  # Load environment variables from .env file
 
-app = Flask(__name__, template_folder='../templates')
+app = Flask(__name__, template_folder='../templates', static_folder='../static')
 # Generate a random secret key for session management
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "dev-secret") 
 socketio = SocketIO(app, cors_allowed_origins="*")

--- a/static/pcm_collector.js
+++ b/static/pcm_collector.js
@@ -1,0 +1,17 @@
+class PCMCollector extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input.length > 0) {
+      const channelData = input[0];
+      const pcm = new Int16Array(channelData.length);
+      for (let i = 0; i < channelData.length; i++) {
+        const s = Math.max(-1, Math.min(1, channelData[i]));
+        pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      }
+      this.port.postMessage(pcm);
+    }
+    return true;
+  }
+}
+
+registerProcessor('pcm-collector', PCMCollector);


### PR DESCRIPTION
## Summary
- Add AudioWorklet `pcm_collector.js` for collecting PCM data
- Configure Flask to serve top-level `static` directory

## Testing
- `python -m py_compile Agent_Bob_Codex/src/app.py`
- Started app and `curl http://127.0.0.1:5000/static/pcm_collector.js`

------
https://chatgpt.com/codex/tasks/task_e_68a49e7578e08330aa12197730e9603c